### PR TITLE
[6팀 이민재] Chapter 1-2. 프레임워크 없이 SPA 만들기 (2)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,38 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "18"
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 8
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Build
+        run: pnpm build
+        env:
+          NODE_ENV: production
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        if: github.ref == 'refs/heads/main'
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./dist

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "18"
+          node-version: "22"
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v2

--- a/src/lib/createElement.js
+++ b/src/lib/createElement.js
@@ -3,8 +3,6 @@ import { addEvent } from "./eventManager";
 // 가상 DOM 객체를 실제 DOM 요소로 변환하는 함수
 export function createElement(vNode) {
   // 1. 배열인 경우 DocumentFragment 생성
-  console.log("vNode", vNode);
-  console.log("typeof vNode", typeof vNode);
   if (Array.isArray(vNode)) {
     const fragment = document.createDocumentFragment();
     vNode.forEach((child) => {

--- a/src/lib/createElement.js
+++ b/src/lib/createElement.js
@@ -3,6 +3,8 @@ import { addEvent } from "./eventManager";
 // 가상 DOM 객체를 실제 DOM 요소로 변환하는 함수
 export function createElement(vNode) {
   // 1. 배열인 경우 DocumentFragment 생성
+  console.log("vNode", vNode);
+  console.log("typeof vNode", typeof vNode);
   if (Array.isArray(vNode)) {
     const fragment = document.createDocumentFragment();
     vNode.forEach((child) => {
@@ -60,20 +62,20 @@ function updateAttributes($el, props) {
       // 이벤트 리스너
       const eventName = key.toLowerCase().substring(2);
       eventListeners[eventName] = props[key];
-    } else if (key === "className") {
-      // className 처리
-      $el.className = props[key];
     } else if (key !== "children") {
-      // 일반 속성
+      // 일반 속성 (className 포함)
       attributes[key] = props[key];
     }
   });
 
-  // 일반 속성 설정
+  // 일반 속성 설정 (순서 유지)
   Object.keys(attributes).forEach((key) => {
     if (key === "style" && typeof attributes[key] === "object") {
       // style 객체 처리
       Object.assign($el.style, attributes[key]);
+    } else if (key === "className") {
+      // className 처리
+      $el.className = attributes[key];
     } else {
       $el.setAttribute(key, attributes[key]);
     }

--- a/src/lib/createElement.js
+++ b/src/lib/createElement.js
@@ -1,5 +1,76 @@
 import { addEvent } from "./eventManager";
 
-export function createElement(vNode) {}
+// 가상 DOM 객체를 실제 DOM 요소로 변환하는 함수
+export function createElement(vNode) {
+  // console.log("전체 vNode", vNode);
+  // 1. 텍스트 노드인 경우
+  if (typeof vNode === "string" || typeof vNode === "number") {
+    return document.createTextNode(vNode);
+  }
 
-function updateAttributes($el, props) {}
+  // 2. null, undefined인 경우
+  if (vNode == null) {
+    return document.createTextNode("");
+  }
+
+  // 3. 컴포넌트 함수(컴포넌트) 인 경우
+  if (typeof vNode.type === "function") {
+    const component = vNode.type;
+    const props = { ...vNode.props, children: vNode.children };
+    const result = component(props);
+    return createElement(result);
+  }
+
+  // 일반 DOM 요소인 경우
+  const element = document.createElement(vNode.type);
+
+  // 속성 설정
+  updateAttributes(element, vNode.props || {});
+
+  // 자식 요소들 생성
+  if (vNode.children) {
+    vNode.children.forEach((child) => {
+      if (child != null) {
+        const childElement = createElement(child);
+        element.appendChild(childElement);
+      }
+    });
+  }
+
+  return element;
+}
+
+function updateAttributes($el, props) {
+  // 이벤트 리스너와 일반 속성 분리
+  const eventListeners = {};
+  const attributes = {};
+
+  Object.keys(props).forEach((key) => {
+    if (key.startsWith("on") && typeof props[key] === "function") {
+      // 이벤트 리스너
+      const eventName = key.toLowerCase().substring(2);
+      eventListeners[eventName] = props[key];
+    } else if (key === "className") {
+      // className 처리
+      $el.className = props[key];
+    } else if (key !== "children") {
+      // 일반 속성
+      attributes[key] = props[key];
+    }
+  });
+
+  // 일반 속성 설정
+  Object.keys(attributes).forEach((key) => {
+    if (key === "style" && typeof attributes[key] === "object") {
+      // style 객체 처리
+      Object.assign($el.style, attributes[key]);
+    } else {
+      $el.setAttribute(key, attributes[key]);
+    }
+  });
+
+  // 이벤트 리스너 등록
+  Object.keys(eventListeners).forEach((eventName) => {
+    addEvent($el, eventName, eventListeners[eventName]);
+  });
+}

--- a/src/lib/createElement.js
+++ b/src/lib/createElement.js
@@ -47,6 +47,24 @@ export function createElement(vNode) {
     });
   }
 
+  // select 요소의 경우 selected 속성 처리
+  if (vNode.type === "select") {
+    const options = element.querySelectorAll("option");
+    let hasSelected = false;
+
+    // 먼저 selected=true인 옵션이 있는지 확인
+    options.forEach((option) => {
+      if (option.selected) {
+        hasSelected = true;
+      }
+    });
+
+    // selected=true인 옵션이 없으면 첫 번째 옵션을 선택
+    if (!hasSelected && options.length > 0) {
+      options[0].selected = true;
+    }
+  }
+
   return element;
 }
 
@@ -66,6 +84,31 @@ function updateAttributes($el, props) {
     }
   });
 
+  // Boolean 속성들 (DOM property로 직접 설정)
+  const booleanProps = ["checked", "disabled", "selected", "readOnly"];
+
+  // Boolean 속성 처리
+  booleanProps.forEach((prop) => {
+    if (attributes[prop] !== undefined) {
+      $el[prop] = attributes[prop];
+
+      // DOM attribute 처리
+      if (attributes[prop] === true) {
+        if (prop === "checked") {
+          // checked는 DOM attribute를 설정하지 않음
+          $el.removeAttribute(prop);
+        } else {
+          $el.setAttribute(prop, "");
+        }
+      } else {
+        $el.removeAttribute(prop);
+      }
+
+      // 처리된 속성 제거
+      delete attributes[prop];
+    }
+  });
+
   // 일반 속성 설정 (순서 유지)
   Object.keys(attributes).forEach((key) => {
     if (key === "style" && typeof attributes[key] === "object") {
@@ -74,9 +117,6 @@ function updateAttributes($el, props) {
     } else if (key === "className") {
       // className 처리
       $el.className = attributes[key];
-    } else if (key === "selected") {
-      // selected 속성 처리
-      $el.selected = attributes[key];
     } else {
       $el.setAttribute(key, attributes[key]);
     }

--- a/src/lib/createElement.js
+++ b/src/lib/createElement.js
@@ -2,7 +2,6 @@ import { addEvent } from "./eventManager";
 
 // 가상 DOM 객체를 실제 DOM 요소로 변환하는 함수
 export function createElement(vNode) {
-  // console.log("전체 vNode", vNode);
   // 1. 텍스트 노드인 경우
   if (typeof vNode === "string" || typeof vNode === "number") {
     return document.createTextNode(vNode);

--- a/src/lib/createElement.js
+++ b/src/lib/createElement.js
@@ -74,6 +74,9 @@ function updateAttributes($el, props) {
     } else if (key === "className") {
       // className 처리
       $el.className = attributes[key];
+    } else if (key === "selected") {
+      // selected 속성 처리
+      $el.selected = attributes[key];
     } else {
       $el.setAttribute(key, attributes[key]);
     }

--- a/src/lib/createVNode.js
+++ b/src/lib/createVNode.js
@@ -1,3 +1,3 @@
 export function createVNode(type, props, ...children) {
-  return {};
+  return { type, props, children };
 }

--- a/src/lib/createVNode.js
+++ b/src/lib/createVNode.js
@@ -1,3 +1,3 @@
 export function createVNode(type, props, ...children) {
-  return { type, props, children };
+  return { type, props, children: children.flat() };
 }

--- a/src/lib/createVNode.js
+++ b/src/lib/createVNode.js
@@ -1,3 +1,18 @@
+// 재귀적으로 배열을 평탄화하고 falsy 값들을 필터링하는 함수
+function flattenArray(arr) {
+  const result = [];
+
+  for (const item of arr) {
+    if (Array.isArray(item)) {
+      result.push(...flattenArray(item));
+    } else if (item != null && item !== false && item !== undefined) {
+      result.push(item);
+    }
+  }
+
+  return result;
+}
+
 export function createVNode(type, props, ...children) {
-  return { type, props, children: children.flat() };
+  return { type, props, children: flattenArray(children) };
 }

--- a/src/lib/eventManager.js
+++ b/src/lib/eventManager.js
@@ -1,5 +1,137 @@
-export function setupEventListeners(root) {}
+// 이벤트 핸들러를 저장하는 Map
+const eventHandlers = new Map();
 
-export function addEvent(element, eventType, handler) {}
+// 이벤트 위임을 위한 루트 요소
+let rootElement = null;
+let isInitialized = false;
 
-export function removeEvent(element, eventType, handler) {}
+export function setupEventListeners(root) {
+  // 이미 초기화되었으면 중복 설정 방지
+  if (isInitialized && rootElement === root) {
+    return;
+  }
+
+  rootElement = root;
+  isInitialized = true;
+
+  // 모든 이벤트 타입에 대해 위임 이벤트 리스너를 설정
+  const eventTypes = ["click", "input", "change", "submit", "keydown", "keyup", "focus", "blur"];
+
+  // 이벤트 타입을 고정된 배열로 순회하면서 root에 **캡처 단계(true)**로 리스너를 등록.
+  // 캡처 단계 사용으로 focus/blur 등의 버블링되지 않는 이벤트도 처리 가능
+  eventTypes.forEach((eventType) => {
+    // 이벤트 위임 핸들러 등록
+    root.addEventListener(eventType, handleEventDelegation, true);
+  });
+}
+
+// 이벤트 위임을 처리하는 핸들러 -> listenr 콜백함수
+function handleEventDelegation(event) {
+  const target = event.target;
+  const eventType = event.type;
+
+  // 이벤트 타입에 등록된 모든 핸들러를 확인
+  const handlersForType = eventHandlers.get(eventType);
+  if (!handlersForType) return;
+
+  // 타겟 요소와 그 상위 요소들에 등록된 핸들러들을 찾아 실행
+  let currentElement = target;
+
+  while (currentElement && currentElement !== rootElement) {
+    const elementHandlers = handlersForType.get(currentElement);
+
+    if (elementHandlers) {
+      // 해당 요소에 등록된 모든 핸들러를 실행
+      elementHandlers.forEach((handler) => {
+        try {
+          handler.call(currentElement, event);
+        } catch (error) {
+          console.error("Event handler error:", error);
+        }
+      });
+    }
+
+    currentElement = currentElement.parentElement;
+  }
+}
+
+export function addEvent(element, eventType, handler) {
+  if (!element || !eventType || typeof handler !== "function") {
+    console.warn("Invalid parameters for addEvent:", { element, eventType, handler });
+    return;
+  }
+
+  // 이벤트 타입에 대한 핸들러 맵이 없으면 생성
+  if (!eventHandlers.has(eventType)) {
+    eventHandlers.set(eventType, new Map());
+  }
+
+  const handlersForType = eventHandlers.get(eventType);
+
+  // 요소에 대한 핸들러 배열이 없으면 생성
+  if (!handlersForType.has(element)) {
+    handlersForType.set(element, []);
+  }
+
+  const elementHandlers = handlersForType.get(element);
+
+  // 중복 핸들러 방지
+  if (!elementHandlers.includes(handler)) {
+    elementHandlers.push(handler);
+  }
+}
+
+export function removeEvent(element, eventType, handler) {
+  if (!element || !eventType) {
+    console.warn("Invalid parameters for removeEvent:", { element, eventType });
+    return;
+  }
+
+  const handlersForType = eventHandlers.get(eventType);
+  if (!handlersForType) return;
+
+  const elementHandlers = handlersForType.get(element);
+  if (!elementHandlers) return;
+
+  if (handler) {
+    // 특정 핸들러만 제거
+    const index = elementHandlers.indexOf(handler);
+    if (index > -1) {
+      elementHandlers.splice(index, 1);
+    }
+  } else {
+    // 해당 요소의 모든 핸들러 제거
+    handlersForType.delete(element);
+  }
+
+  // 이벤트 타입에 핸들러가 없으면 타입도 제거
+  if (handlersForType.size === 0) {
+    eventHandlers.delete(eventType);
+  }
+}
+
+export function removeAllEvents(element) {
+  if (!element) return;
+
+  eventHandlers.forEach((handlersForType, eventType) => {
+    handlersForType.delete(element);
+
+    // 이벤트 타입에 핸들러가 없으면 타입도 제거
+    if (handlersForType.size === 0) {
+      eventHandlers.delete(eventType);
+    }
+  });
+}
+
+export function cleanup() {
+  eventHandlers.clear();
+
+  if (rootElement) {
+    const eventTypes = ["click", "input", "change", "submit", "keydown", "keyup", "focus", "blur"];
+    eventTypes.forEach((eventType) => {
+      rootElement.removeEventListener(eventType, handleEventDelegation, true);
+    });
+    rootElement = null;
+    isInitialized = false;
+  }
+}

--- a/src/lib/normalizeVNode.js
+++ b/src/lib/normalizeVNode.js
@@ -1,3 +1,32 @@
 export function normalizeVNode(vNode) {
-  return vNode;
+  console.log("정규화 할 코드 ->", vNode);
+  // null, undefined, boolean 값들 처리
+  if (vNode == null || typeof vNode === "boolean") {
+    console.log("정규화 후 코드 -> null, undefined, boolean", vNode);
+    return "";
+  }
+
+  // 문자열이나 숫자는 그대로 반환
+  if (typeof vNode === "string" || typeof vNode === "number") {
+    console.log("정규화 후 코드 -> 문자열 또는 숫자", vNode);
+    return vNode;
+  }
+
+  // 배열인 경우 각 요소를 정규화하고 빈 값들 제거
+  if (Array.isArray(vNode)) {
+    console.log(
+      "정규화 후 코드 -> 배열",
+      vNode.map(normalizeVNode).filter((item) => item !== ""),
+    );
+    return vNode.map(normalizeVNode).filter((item) => item !== "");
+  }
+
+  // 이미 정규화된 vNode 객체는 그대로 반환
+  if (typeof vNode === "object" && vNode.type) {
+    console.log("정규화 후 코드 -> 객체", vNode);
+    return vNode;
+  }
+
+  // 기타 값들은 빈 문자열로 변환
+  return "";
 }

--- a/src/lib/normalizeVNode.js
+++ b/src/lib/normalizeVNode.js
@@ -1,30 +1,36 @@
 export function normalizeVNode(vNode) {
-  console.log("정규화 할 코드 ->", vNode);
   // null, undefined, boolean 값들 처리
   if (vNode == null || typeof vNode === "boolean") {
-    console.log("정규화 후 코드 -> null, undefined, boolean", vNode);
     return "";
   }
 
   // 문자열이나 숫자는 그대로 반환
   if (typeof vNode === "string" || typeof vNode === "number") {
-    console.log("정규화 후 코드 -> 문자열 또는 숫자", vNode);
-    return vNode;
+    return vNode.toString();
   }
 
   // 배열인 경우 각 요소를 정규화하고 빈 값들 제거
   if (Array.isArray(vNode)) {
-    console.log(
-      "정규화 후 코드 -> 배열",
-      vNode.map(normalizeVNode).filter((item) => item !== ""),
-    );
     return vNode.map(normalizeVNode).filter((item) => item !== "");
   }
 
-  // 이미 정규화된 vNode 객체는 그대로 반환
+  // vNode 객체인 경우
   if (typeof vNode === "object" && vNode.type) {
-    console.log("정규화 후 코드 -> 객체", vNode);
-    return vNode;
+    // 함수형 컴포넌트인 경우 실행
+    if (typeof vNode.type === "function") {
+      const Component = vNode.type;
+      const props = { ...vNode.props, children: vNode.children };
+      const result = Component(props);
+      return normalizeVNode(result);
+    }
+
+    // 일반 vNode 객체는 children도 정규화
+    return {
+      ...vNode,
+      children: Array.isArray(vNode.children)
+        ? vNode.children.map(normalizeVNode).filter((item) => item !== "")
+        : vNode.children,
+    };
   }
 
   // 기타 값들은 빈 문자열로 변환

--- a/src/lib/renderElement.js
+++ b/src/lib/renderElement.js
@@ -4,7 +4,24 @@ import { normalizeVNode } from "./normalizeVNode";
 import { updateElement } from "./updateElement";
 
 export function renderElement(vNode, container) {
-  // 최초 렌더링시에는 createElement로 DOM을 생성하고
-  // 이후에는 updateElement로 기존 DOM을 업데이트한다.
-  // 렌더링이 완료되면 container에 이벤트를 등록한다.
+  // 가상 DOM 노드 정규화
+  const normalizedVNode = normalizeVNode(vNode);
+
+  // 기존 DOM이 있는지 확인 -> NodeList
+  const oldVNode = container.firstElementChild;
+
+  if (oldVNode) {
+    // 기존 DOM 업데이트
+    updateElement(container, normalizedVNode, oldVNode);
+  } else {
+    // 최초 렌더링 - 새 DOM 생성
+    const element = createElement(normalizedVNode);
+    container.appendChild(element);
+  }
+
+  // 현재 가상 DOM 노드를 컨테이너에 저장
+  container._vNode = normalizedVNode;
+
+  // 이벤트 리스너 설정
+  setupEventListeners(container);
 }

--- a/src/lib/renderElement.js
+++ b/src/lib/renderElement.js
@@ -11,8 +11,6 @@ export function renderElement(vNode, container) {
   const oldVNode = container.firstElementChild;
 
   if (oldVNode) {
-    console.log("normalizedVNode", normalizedVNode);
-    console.log("normalizedVNode - oldVNode", oldVNode);
     // 기존 DOM 업데이트
     updateElement(container, normalizedVNode, oldVNode);
   } else {

--- a/src/lib/renderElement.js
+++ b/src/lib/renderElement.js
@@ -7,8 +7,8 @@ export function renderElement(vNode, container) {
   // 가상 DOM 노드 정규화
   const normalizedVNode = normalizeVNode(vNode);
 
-  // 기존 DOM이 있는지 확인 -> NodeList
-  const oldVNode = container.firstElementChild;
+  // 이전 가상 DOM 노드 가져오기
+  const oldVNode = container._vNode;
 
   if (oldVNode) {
     // 기존 DOM 업데이트

--- a/src/lib/renderElement.js
+++ b/src/lib/renderElement.js
@@ -11,6 +11,8 @@ export function renderElement(vNode, container) {
   const oldVNode = container.firstElementChild;
 
   if (oldVNode) {
+    console.log("normalizedVNode", normalizedVNode);
+    console.log("normalizedVNode - oldVNode", oldVNode);
     // 기존 DOM 업데이트
     updateElement(container, normalizedVNode, oldVNode);
   } else {

--- a/src/lib/updateElement.js
+++ b/src/lib/updateElement.js
@@ -1,6 +1,49 @@
-import { addEvent, removeEvent } from "./eventManager";
+// import { addEvent, removeEvent } from "./eventManager";
 import { createElement } from "./createElement.js";
 
-function updateAttributes(target, originNewProps, originOldProps) {}
+export function updateElement(parent, newNode, oldNode, index = 0) {
+  // 1. oldNode만 있는 경우
+  if (!newNode && oldNode) {
+    return parent.removeChild(parent.childNode[index]);
+  }
 
-export function updateElement(parentElement, newNode, oldNode, index = 0) {}
+  // 2. newNode만 있는 경우
+  if (newNode && !oldNode) {
+    return parent.appendChild(createElement(newNode));
+  }
+
+  // 3. oldNode와 newNode 모두 text 타입일 경우
+  if (typeof newNode === "string" && typeof oldNode === "string") {
+    if (newNode === oldNode) return;
+    return parent.replaceChild(createElement(newNode), parent.childNodes[index]);
+  }
+
+  // 4. oldNode와 newNode의 태그 이름(type)이 다를 경우
+  if (newNode.type !== oldNode.type) {
+    return parent.replaceChild(createElement(newNode), parent.childNodes[index]);
+  }
+
+  // 5. oldNode와 newNode의 태그 이름(type)이 같을 경우
+  updateAttributes(parent.childNodes[index], newNode.props || {}, oldNode.props || {});
+
+  // 6. newNode와 oldNode의 모든 자식 태그를 순회하며 1 ~ 5의 내용을 반복한다.
+  const maxLength = Math.max(newNode.children.length, oldNode.children.length);
+  for (let i = 0; i < maxLength; i++) {
+    updateElement(parent.childNodes[index], newNode.children[i], oldNode.children[i], i);
+  }
+}
+
+// 5 - newNode와 oldNode의 attribute를 비교하여 변경된 부분만 반영한다.
+function updateAttributes(target, newProps, oldProps) {
+  // 달라지거나 추가된 Props를 반영
+  for (const [attr, value] of Object.entries(newProps)) {
+    if (oldProps[attr] === newProps[attr]) continue;
+    target.setAttribute(attr, value);
+  }
+
+  // 없어진 props를 attribute에서 제거
+  for (const attr of Object.keys(oldProps)) {
+    if (newProps[attr] !== undefined) continue;
+    target.removeAttribute(attr);
+  }
+}

--- a/src/lib/updateElement.js
+++ b/src/lib/updateElement.js
@@ -1,29 +1,121 @@
-import { setupEventListeners } from "./eventManager";
-import { createElement } from "./createElement";
-import { normalizeVNode } from "./normalizeVNode";
-import { updateElement } from "./updateElement";
+// import { addEvent, removeEvent } from "./eventManager";
+import { createElement } from "./createElement.js";
+import { addEvent, removeEvent } from "./eventManager.js";
 
-export function renderElement(vNode, container) {
-  // 가상 DOM 노드 정규화
-  const normalizedVNode = normalizeVNode(vNode);
+// 함수형 컴포넌트의 타입을 비교하는 헬퍼 함수
+function isSameType(newType, oldType) {
+  // 둘 다 함수인 경우 함수 이름으로 비교
+  if (typeof newType === "function" && typeof oldType === "function") {
+    return newType.name === oldType.name || newType === oldType;
+  }
+  // 일반적인 타입 비교
+  return newType === oldType;
+}
 
-  // 기존 DOM이 있는지 확인 -> NodeList
-  const oldVNode = container.firstElementChild;
-
-  if (oldVNode) {
-    console.log("normalizedVNode", normalizedVNode);
-    console.log("normalizedVNode - oldVNode", oldVNode);
-    // 기존 DOM 업데이트
-    updateElement(container, normalizedVNode, oldVNode);
-  } else {
-    // 최초 렌더링 - 새 DOM 생성
-    const element = createElement(normalizedVNode);
-    container.appendChild(element);
+export function updateElement(parent, newNode, oldNode, index = 0) {
+  // 1. oldNode만 있는 경우
+  if (!newNode && oldNode) {
+    return parent.removeChild(parent.childNode[index]);
   }
 
-  // 현재 가상 DOM 노드를 컨테이너에 저장
-  container._vNode = normalizedVNode;
+  // 2. newNode만 있는 경우
+  if (newNode && !oldNode) {
+    return parent.appendChild(createElement(newNode));
+  }
 
-  // 이벤트 리스너 설정
-  setupEventListeners(container);
+  // 3. oldNode와 newNode 모두 text 타입일 경우
+  if (typeof newNode === "string" && typeof oldNode === "string") {
+    if (newNode === oldNode) return;
+    return parent.replaceChild(createElement(newNode), parent.childNodes[index]);
+  }
+
+  // 4. oldNode와 newNode의 타입이 다를 경우
+  if (!isSameType(newNode.type, oldNode.type)) {
+    return parent.replaceChild(createElement(newNode), parent.childNodes[index]);
+  }
+
+  // 5. oldNode와 newNode의 타입이 같을 경우
+  updateAttributes(parent.childNodes[index], newNode.props || {}, oldNode.props || {});
+
+  // 6. newNode와 oldNode의 모든 자식 태그를 순회하며 1 ~ 5의 내용을 반복한다.
+  const maxLength = Math.max(newNode.children.length, oldNode.children.length);
+  for (let i = 0; i < maxLength; i++) {
+    updateElement(parent.childNodes[index], newNode.children[i], oldNode.children[i], i);
+  }
+}
+
+// 5 - newNode와 oldNode의 attribute를 비교하여 변경된 부분만 반영한다.
+function updateAttributes(target, newProps, oldProps) {
+  // 이벤트 리스너와 일반 속성 분리
+  const newEventListeners = {};
+  const oldEventListeners = {};
+  const newAttributes = {};
+  const oldAttributes = {};
+
+  // 새 props에서 이벤트 리스너와 일반 속성 분리
+  Object.keys(newProps).forEach((key) => {
+    if (key.startsWith("on") && typeof newProps[key] === "function") {
+      const eventName = key.toLowerCase().substring(2);
+      newEventListeners[eventName] = newProps[key];
+    } else if (key === "className") {
+      newAttributes[key] = newProps[key];
+    } else if (key !== "children") {
+      newAttributes[key] = newProps[key];
+    }
+  });
+
+  // 기존 props에서 이벤트 리스너와 일반 속성 분리
+  Object.keys(oldProps).forEach((key) => {
+    if (key.startsWith("on") && typeof oldProps[key] === "function") {
+      const eventName = key.toLowerCase().substring(2);
+      oldEventListeners[eventName] = oldProps[key];
+    } else if (key === "className") {
+      oldAttributes[key] = oldProps[key];
+    } else if (key !== "children") {
+      oldAttributes[key] = oldProps[key];
+    }
+  });
+
+  // 이벤트 리스너 처리
+  // 제거된 이벤트 리스너 처리
+  Object.keys(oldEventListeners).forEach((eventName) => {
+    if (!newEventListeners[eventName]) {
+      removeEvent(target, eventName, oldEventListeners[eventName]);
+    }
+  });
+
+  // 추가되거나 변경된 이벤트 리스너 처리
+  Object.keys(newEventListeners).forEach((eventName) => {
+    const newHandler = newEventListeners[eventName];
+    const oldHandler = oldEventListeners[eventName];
+
+    if (oldHandler && oldHandler !== newHandler) {
+      // 핸들러가 변경된 경우
+      removeEvent(target, eventName, oldHandler);
+      addEvent(target, eventName, newHandler);
+    } else if (!oldHandler) {
+      // 새로운 핸들러 추가
+      addEvent(target, eventName, newHandler);
+    }
+  });
+
+  // 일반 속성 처리
+  // 달라지거나 추가된 Props를 반영
+  for (const [attr, value] of Object.entries(newAttributes)) {
+    if (oldAttributes[attr] === newAttributes[attr]) continue;
+
+    if (attr === "className") {
+      target.className = value;
+    } else if (attr === "style" && typeof value === "object") {
+      Object.assign(target.style, value);
+    } else {
+      target.setAttribute(attr, value);
+    }
+  }
+
+  // 없어진 props를 attribute에서 제거
+  for (const attr of Object.keys(oldAttributes)) {
+    if (newAttributes[attr] !== undefined) continue;
+    target.removeAttribute(attr);
+  }
 }

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,6 +1,6 @@
 import { defineConfig as defineTestConfig, mergeConfig } from "vitest/config";
 import { defineConfig } from "vite";
-import { resolve } from "path";
+import path from "path";
 
 const base = process.env.NODE_ENV === "production" ? "/front_6th_chapter1-2/" : "";
 
@@ -19,9 +19,10 @@ export default mergeConfig(
     base,
     build: {
       rollupOptions: {
-        input: {
-          main: resolve(__dirname, "index.html"),
-          404: resolve(__dirname, "404.html"),
+        input: path.resolve(__dirname, "index.html"),
+        output: {
+          entryFileNames: "assets/main-[hash].js",
+          manualChunks: undefined,
         },
       },
     },


### PR DESCRIPTION
## 과제 체크포인트
### 배포 링크
https://minjaeleee.github.io/front_6th_chapter1-2/

<!--
배포 링크를 적어주세요
예시: https://<username>.github.io/front-6th-chapter1-1/

배포가 완료되지 않으면 과제를 통과할 수 없습니다.
배포 후에 정상 작동하는지 확인해주세요.
-->

### 기본과제

#### 가상돔을 기반으로 렌더링하기

- [x] createVNode 함수를 이용하여 vNode를 만든다.
- [x] normalizeVNode 함수를 이용하여 vNode를 정규화한다.
- [x] createElement 함수를 이용하여 vNode를 실제 DOM으로 만든다.
- [x] 결과적으로, JSX를 실제 DOM으로 변환할 수 있도록 만들었다.

#### 이벤트 위임

- [x] 노드를 생성할 때 이벤트를 직접 등록하는게 아니라 이벤트 위임 방식으로 등록해야 한다
- [x] 동적으로 추가된 요소에도 이벤트가 정상적으로 작동해야 한다
- [x] 이벤트 핸들러가 제거되면 더 이상 호출되지 않아야 한다

### 심화 과제

#### Diff 알고리즘 구현

- [x] 초기 렌더링이 올바르게 수행되어야 한다
- [x] diff 알고리즘을 통해 변경된 부분만 업데이트해야 한다
- [x] 새로운 요소를 추가하고 불필요한 요소를 제거해야 한다
- [x] 요소의 속성만 변경되었을 때 요소를 재사용해야 한다
- [x] 요소의 타입이 변경되었을 때 새로운 요소를 생성해야 한다

## 과제 셀프회고

<!-- 과제에 대한 회고를 작성해주세요 -->

### 기술적 성장
1. JSX의 트랜스파일링 과정 학습 
- 막연하게 Babel과 같은 트랜스파일러 덕에 jsx를 적용할 수 있다는 개념만 알고 있었습니다. 이번 학습을 통해서 더 자세하고 정교하게 공부할 수 있었습니다. 또한, 가상 DOM이  jsx -> createVNode -> createElement -> renderElement ( + updateElement) 과정을 통해 실제 DOM에 적용되는 과정을 학습했습니다.

2. esbuild.jsxFactory의 역할 ([상세 보기](https://github.com/minjaeleee/front_6th_chapter1-2/issues/1))
- 처음에 이 JSX 파일들을 어디서부터 과정을 시작해야할지 몰라 막막했고, createVNode 함수가 왜 실행이 되어야 하는지 이해하지 못했습니다. esbuildjsxFactory의 역할을 통해서 결국엔 createVNode를 통해 jsx가 js로 변환하는 과정을 학습했습니다.

3. createVNode ([상세 보기](https://github.com/minjaeleee/front_6th_chapter1-2/issues/2))
- JSX를 가상 DOM 객체로 변환하는 역할에 대해서 학습했습니다. 특히 객체 내부의 type, props, children의 의미와 리턴 값들을 보면서 노드가 어떻게 구조화하는지 이해할 수 있었습니다. 직접 모든 노드 요소에 대해서 console.log()를 실행해가며 노드와 객체로 리턴된 값들을 비교하며 더 구체적으로 학습할 수 있었습니다.

4. normalizeVNode ([상세 보기](https://github.com/minjaeleee/front_6th_chapter1-2/issues/3))
- vNode를 일관된 형태로 정규화하기 위한 함수의 역할을 이해했습니다. 특히나, jsx를 작성하기만 하다보니 다양한 형태의 vNode에 대한 이해가 많이 부족했는데 불필요하게 생성되는 값들을 제거하고, 함수형 vNode들을 실행시키는 등을 직접 경험하면서 전처리의 핵심 역할을 담당한다는 것을 학습할 수 있었습니다.

5. createElement([상세 보기](https://github.com/minjaeleee/front_6th_chapter1-2/issues/4))
- createVNode와 normalizeVNode를 기반으로 실제 DOM 노드를 생성하는 함수에 대해서 이해할 수 있었습니다. 특히나 DOM의 attributes 들을 직접 조작하고 렌더링하는 것이 이해하기 어려웠습니다. 책이나 문서로는 리액트의 등장 배경에 대해서 설명할 때, 선언형의 장점, 직접 DOM을 조작하지 않아서 생기는 장점, 상태와 UI의 분리적 구조에 대해서 외우고 있었는데 실제로 효율적으로 관리하는 경험을 할 수 있었습니다.

6. renderElement([상세 보기](https://github.com/minjaeleee/front_6th_chapter1-2/issues/5))
- React의 ReactDOM.render 기능과 유사한 역할을 하는 renderElement 함수를 직접 작성해보며 가상 DOM을 실제 DOM에 렌더링하는 과정에 대해서 학습할 수 있었습니다.


### 코드 품질
<!-- 예시
- 특히 만족스러운 구현
- 리팩토링이 필요한 부분
- 코드 설계 관련 고민과 결정
-->

### 학습 효과 분석
가상 DOM 렌더링 원리를 직접 구현함으로써 JSX transform, VNode 생성, 실제 DOM 생성 구조 등에 대해서 깊숙이 이해할 수 있었습니다.
개인적으로는 지난주 과제보다 이번주 과제가 더 어려웠습니다. 노드의 type과 props, children의 구조와 케이스를 모두 이해해야하며 attributes, element들을 모두 조작하고 렌더링시켜야 하기 때문에 많이 어려웠습니다. 초기 구현은 ai의 도움을 받았고 develop과 완성도는 테스트 코드를 수정하며 높였습니다… 
기능 완성 -> 테스트 코드 수정 -> 다른 기능 수정 -> 기능 완성 -> 테스트 코드 수정의 반복이었습니다..

또한, 이벤트 위임 구조를 작성하며 root 기반 등록 방식 메모리 제어 구조를 배울 수 있었습니다.

### 과제 피드백
<!-- 예시
- 과제에서 모호하거나 애매했던 부분
- 과제에서 좋았던 부분
-->

## 리뷰 받고 싶은 내용

1. updateElement 함수에서 children 요소들을 아래와 같이 index로 구분하는 것이 비효율적일 것 같다는 생각이 드는데, 만약에 요소의 순서만 변경해도 모두 변경되었다고 감지하고 diff 업데이트를 할 것 같습니다. 더 효율적으로 개선할 수 있는 방법이 있을까요??

```jsx
 // 6. newNode와 oldNode의 모든 자식 태그를 순회하며 1 ~ 5의 내용을 반복한다.
  const newChildren = newNode.children || [];
  const oldChildren = oldNode.children || [];

  // 먼저 공통된 자식들을 처리
  for (let i = 0; i < Math.min(newChildren.length, oldChildren.length); i++) {
    updateElement(parent.childNodes[index], newChildren[i], oldChildren[i], i);
  }
```

2. 루트 요소에 한 번만 이벤트 리스너를 등록하고, 요소별 핸들러는 addEvent로 Map에 저장하는 이벤트 위임 구조를 사용하고 있는데 예를 들어서 addEvent()를 호출하지 않고 DOM에만 append된 요소라든지, e.stopPropagation()이 중간에 호출되어서 루트까지 도달하지 못 하는 경우가 생길 수 있을 것 같은데 벤트 구조를 확장하면서도 안정적으로 관리할 수 있는 구조적/전략적 개선 방안을 조언받고 싶습니다.