### PR TITLE
[2팀 이진희] Chapter 1-2. 프레임워크 없이 SPA 만들기 (2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "pnpm": ">=10"
   },
   "type": "module",
+  "homepage": "https://bebusl.github.io/front_6th_chapter1-2/",
   "scripts": {
     "dev": "vite",
     "build": "vite build",

--- a/src/lib/createElement.js
+++ b/src/lib/createElement.js
@@ -1,4 +1,4 @@
-// import { addEvent } from "./eventManager";
+import { addEvent } from "./eventManager";
 import { normalizeVNode } from "./normalizeVNode";
 
 export function createElement(vNode) {
@@ -19,9 +19,7 @@ export function createElement(vNode) {
   if (typeof vNode.type === "function") throw Error;
 
   const element = document.createElement(vNode.type);
-
   if (vNode.props) updateAttributes(element, vNode.props);
-
   vNode.children.forEach((child) => {
     element.appendChild(createElement(child));
   });
@@ -32,6 +30,12 @@ export function createElement(vNode) {
 function updateAttributes($el, props) {
   for (const [key, value] of Object.entries(props || {})) {
     let normalizedKey = key === "className" ? "class" : key;
+
+    if (normalizedKey.startsWith("on") && typeof value === "function") {
+      const eventType = normalizedKey.substring(2).toLowerCase();
+      addEvent($el, eventType, value);
+      continue;
+    }
 
     if (value !== undefined && value !== null) {
       $el.setAttribute(normalizedKey, value);

--- a/src/lib/createElement.js
+++ b/src/lib/createElement.js
@@ -1,5 +1,40 @@
-import { addEvent } from "./eventManager";
+// import { addEvent } from "./eventManager";
+import { normalizeVNode } from "./normalizeVNode";
 
-export function createElement(vNode) {}
+export function createElement(vNode) {
+  if (Array.isArray(vNode)) {
+    const fragment = document.createDocumentFragment();
 
-function updateAttributes($el, props) {}
+    vNode.forEach((v) => {
+      const element = document.createElement(v.type);
+      v.children.forEach((child) => element.appendChild(createElement(child)));
+      fragment.appendChild(element);
+    });
+    return fragment;
+  }
+  const normalizedVNode = normalizeVNode(vNode);
+
+  if (typeof normalizedVNode === "string") return document.createTextNode(normalizedVNode);
+
+  if (typeof vNode.type === "function") throw Error;
+
+  const element = document.createElement(vNode.type);
+
+  if (vNode.props) updateAttributes(element, vNode.props);
+
+  vNode.children.forEach((child) => {
+    element.appendChild(createElement(child));
+  });
+
+  return element;
+}
+
+function updateAttributes($el, props) {
+  for (const [key, value] of Object.entries(props || {})) {
+    let normalizedKey = key === "className" ? "class" : key;
+
+    if (value !== undefined && value !== null) {
+      $el.setAttribute(normalizedKey, value);
+    }
+  }
+}

--- a/src/lib/createElement.js
+++ b/src/lib/createElement.js
@@ -36,7 +36,10 @@ function updateAttributes($el, props) {
       addEvent($el, eventType, value);
       continue;
     }
-
+    if (typeof value === "boolean") {
+      if (value) $el.setAttribute(normalizedKey, "");
+      continue;
+    }
     if (value !== undefined && value !== null) {
       $el.setAttribute(normalizedKey, value);
     }

--- a/src/lib/createVNode.js
+++ b/src/lib/createVNode.js
@@ -1,3 +1,7 @@
 export function createVNode(type, props, ...children) {
-  return {};
+  return {
+    type,
+    props,
+    children: children.flat(Infinity).filter((v) => v !== null && v !== undefined && v !== false),
+  };
 }

--- a/src/lib/eventManager.js
+++ b/src/lib/eventManager.js
@@ -1,5 +1,29 @@
-export function setupEventListeners(root) {}
+const eventRegistry = [];
 
-export function addEvent(element, eventType, handler) {}
+export function setupEventListeners(root) {
+  const eventTypes = [...new Set(eventRegistry.map((e) => e.eventType))];
 
-export function removeEvent(element, eventType, handler) {}
+  for (const eventType of eventTypes) {
+    root.addEventListener(eventType, (event) => {
+      for (const { element, eventType: type, handler } of eventRegistry) {
+        if (type !== eventType) continue;
+        if (element.contains(event.target) || element === event.target) {
+          handler(event);
+        }
+      }
+    });
+  }
+}
+
+export function addEvent(element, eventType, handler) {
+  eventRegistry.push({ element, eventType, handler });
+}
+
+export function removeEvent(element, eventType, handler) {
+  const index = eventRegistry.findIndex(
+    (e) => e.element === element && e.eventType === eventType && e.handler === handler,
+  );
+  if (index !== -1) {
+    eventRegistry.splice(index, 1);
+  }
+}

--- a/src/lib/normalizeVNode.js
+++ b/src/lib/normalizeVNode.js
@@ -1,3 +1,19 @@
 export function normalizeVNode(vNode) {
+  if (typeof vNode === "boolean" || vNode === undefined || vNode === null) {
+    return "";
+  }
+  if (typeof vNode === "string" || typeof vNode === "number") return `${vNode}`;
+
+  if (typeof vNode.type === "function") {
+    const mergedProps = { ...(vNode.props || {}), children: vNode.children };
+    return normalizeVNode(vNode.type(mergedProps));
+  }
+
+  // 자식들도 normalize
+  if (Array.isArray(vNode.children)) {
+    const normalizedChildren = vNode.children.map((child) => normalizeVNode(child)).filter((value) => value !== "");
+    vNode.children = normalizedChildren;
+  }
+
   return vNode;
 }

--- a/src/lib/renderElement.js
+++ b/src/lib/renderElement.js
@@ -1,10 +1,17 @@
+// import { removeEvent, setupEventListeners } from "./eventManager";
 import { setupEventListeners } from "./eventManager";
 import { createElement } from "./createElement";
 import { normalizeVNode } from "./normalizeVNode";
-import { updateElement } from "./updateElement";
+// import { updateElement } from "./updateElement";
 
 export function renderElement(vNode, container) {
-  // 최초 렌더링시에는 createElement로 DOM을 생성하고
-  // 이후에는 updateElement로 기존 DOM을 업데이트한다.
-  // 렌더링이 완료되면 container에 이벤트를 등록한다.
+  const result = createElement(normalizeVNode(vNode));
+
+  if (container.firstChild) {
+    container.replaceChildren(result);
+  } else {
+    container.appendChild(result);
+  }
+
+  setupEventListeners(result);
 }

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,6 +1,7 @@
 import { defineConfig as defineTestConfig, mergeConfig } from "vitest/config";
 import { defineConfig } from "vite";
 import { resolve } from "path";
+import fs from "fs";
 
 const base = process.env.NODE_ENV === "production" ? "/front_6th_chapter1-2/" : "";
 
@@ -23,10 +24,18 @@ export default mergeConfig(
       rollupOptions: {
         input: {
           main: resolve(__dirname, "index.html"),
-          404: resolve(__dirname, "404.html"),
+          404: resolve(__dirname, "index.html"),
         },
       },
     },
+    plugins: [
+      {
+        name: "copy-index-to-404",
+        closeBundle() {
+          fs.copyFileSync(resolve(__dirname, "dist/index.html"), resolve(__dirname, "dist/404.html"));
+        },
+      },
+    ],
   }),
   defineTestConfig({
     test: {


### PR DESCRIPTION
## 과제 체크포인트
### 배포 링크
https://bebusl.github.io/front_6th_chapter1-2/


### 기본과제

#### 가상돔을 기반으로 렌더링하기

- [x] createVNode 함수를 이용하여 vNode를 만든다.
- [x] normalizeVNode 함수를 이용하여 vNode를 정규화한다.
- [x] createElement 함수를 이용하여 vNode를 실제 DOM으로 만든다.
- [x] 결과적으로, JSX를 실제 DOM으로 변환할 수 있도록 만들었다.

#### 이벤트 위임

- [x] 노드를 생성할 때 이벤트를 직접 등록하는게 아니라 이벤트 위임 방식으로 등록해야 한다
- [x] 동적으로 추가된 요소에도 이벤트가 정상적으로 작동해야 한다
- [x] 이벤트 핸들러가 제거되면 더 이상 호출되지 않아야 한다

### 심화 과제

#### Diff 알고리즘 구현

- [x] 초기 렌더링이 올바르게 수행되어야 한다
- [ ] diff 알고리즘을 통해 변경된 부분만 업데이트해야 한다
- [ ] 새로운 요소를 추가하고 불필요한 요소를 제거해야 한다
- [ ] 요소의 속성만 변경되었을 때 요소를 재사용해야 한다
- [ ] 요소의 타입이 변경되었을 때 새로운 요소를 생성해야 한다

## 과제 셀프회고

<!-- 과제에 대한 회고를 작성해주세요 -->
이번주 뜬금없는 코로나에 걸려 정신없이 보냈습니다;;
심화과제는 진행하지 못했지만, 기본과제를 하면서 가상돔의 역할과 기존에 jsx가 어떻게 DOM으로 변환되는지 과정을 알 수 있어 좋은 경험이었던 것 같습니다.
심화과제는 다음주가 시작되기 전에 꼭 한 번 해결해보고 넘어가려고 합니다.


### 궁금한점
저는 얼리 리턴을 매우 선호하는 편인데요,(얼리 리턴 가능한 거의 모든 상황에서 얼리 리턴을 하는 편인 것 같습니다.)
얼리 리턴을 비선호하시는 분들도 있다고 알고 있어서요. 
코치님은 얼리 리턴을 선호하시는 편인지, 어떠한 경우에는 얼리 리턴을 쓰고 그 외 조건문으로 분기 처리하시는 지 궁금합니다.


